### PR TITLE
Bump required "catalog" version to 0.5.0-alpha (Issue #20)

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -19,7 +19,7 @@
     "require": {
         "php": "^5.6.0|^7.0",
         "colinmollenhour/credis": "1.5",
-        "lizards-and-pumpkins/catalog": "0.4.0-alpha"
+        "lizards-and-pumpkins/catalog": "0.5.0-alpha"
     },
     "require-dev": {
         "phpunit/phpunit": "5.3.*",


### PR DESCRIPTION
Closes #20.